### PR TITLE
MG-51: enhance sorting functionality in Sort.vue

### DIFF
--- a/components/general/Sort.vue
+++ b/components/general/Sort.vue
@@ -7,16 +7,19 @@
 </template>
 <script lang="ts" setup>
 import Dropdown from '~/components/general/Dropdown.vue'
+import { useControls } from '~/composables/controls'
 
-const { sortBy, sortDirection } = defineProps<{
+const props = defineProps<{
   sortBy: string
   sortDirection: 'asc' | 'desc'
 }>()
 
 const emit = defineEmits<{
-  [update: sortBy]: string
-  [update: sortDirection]: 'asc' | 'desc'
+  sortBy: string
+  sortDirection: 'asc' | 'desc'
 }>()
+
+const { routeParams } = await useControls()
 
 const sortOptions = [
   { label: 'poslední změny', value: 'updated_at', direction: 'desc' },
@@ -29,12 +32,30 @@ const sortOptions = [
 
 const model = ref(sortOptions[0].value)
 
+onMounted(() => {
+  if (props.sortBy !== sortOptions[0].value) {
+    routeParams.sortBy = props.sortBy
+  }
+
+  if (props.sortDirection !== sortOptions[0].direction) {
+    routeParams.sortDirection = props.sortDirection
+  }
+})
+
 const onUpdate = (value: string) => {
   const option = sortOptions.find((option) => option.value === value)
 
   if (option) {
     emit('update:sortBy', option.value)
     emit('update:sortDirection', option.direction)
+
+    option.value === sortOptions[0].value
+      ? delete routeParams.sortBy
+      : (routeParams.sortBy = option.value)
+
+    option.direction === sortOptions[0].direction
+      ? delete routeParams.sortDirection
+      : (routeParams.sortDirection = option.direction)
   }
 }
 </script>

--- a/components/general/Sort.vue
+++ b/components/general/Sort.vue
@@ -30,7 +30,7 @@ const sortOptions = [
   { label: 'náhodně', value: 'random', direction: 'asc' },
 ] as const
 
-const model = ref(sortOptions[0].value)
+const model = ref<(typeof sortOptions)[number]['value']>(sortOptions[0].value)
 
 onMounted(() => {
   if (props.sortBy !== sortOptions[0].value) {
@@ -40,6 +40,9 @@ onMounted(() => {
   if (props.sortDirection !== sortOptions[0].direction) {
     routeParams.sortDirection = props.sortDirection
   }
+
+  model.value =
+    sortOptions.find((option) => option.value === props.sortBy)?.value ?? sortOptions[0].value
 })
 
 const onUpdate = (value: string) => {

--- a/plugins/controls.ts
+++ b/plugins/controls.ts
@@ -20,7 +20,7 @@ interface Response {
 const controlsService = async (
   options: IFilterConfig = {
     sortBy: 'updated_at',
-    sortDirection: 'asc',
+    sortDirection: 'desc',
     perPage: 12,
   }
 ) => {


### PR DESCRIPTION
- Imported `useControls` from composables/controls
- Refactored props definition and emit events for better readability
- Added routeParams from useControls to manage sort parameters
- Implemented onMounted hook to update routeParams based on props values
- Updated onUpdate function to modify routeParams based on selected options
- Changed default sortDirection in controls.ts plugin from 'asc' to 'desc'